### PR TITLE
Fix error when unloading items during a save/load cycle

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_UnloadYourInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_UnloadYourInventory.cs
@@ -21,7 +21,13 @@ namespace CombatExtended
 		
 		private int amountToDrop;
 
-        public override bool TryMakePreToilReservations(bool errorOnFailed)
+		public override void ExposeData()
+		{
+			base.ExposeData();
+			Scribe_Values.Look(ref amountToDrop, "amountToDrop", -1, false);
+		}
+
+		public override bool TryMakePreToilReservations(bool errorOnFailed)
         {
             return true;
         }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
