### PR TITLE
Use default 1.0f body size for turrets (non-pawns) when resisting stun

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
+++ b/Source/CombatExtended/Harmony/Harmony_StunHandler.cs
@@ -22,11 +22,15 @@ namespace CombatExtended.HarmonyCE
 	{
 
 	    Pawn pawn = __instance.parent as Pawn;
-	    if (pawn == null || pawn.Downed || pawn.Dead)
+            float bodySize = 1.0f;
+	    if (pawn != null)
 	    {
-		return false;
+                if (pawn.Downed || pawn.Dead)
+                {
+                    return false;
+                }
+		bodySize = pawn.BodySize;
 	    }
-	    float bodySize = pawn.BodySize;
 	    
 	    if (dinfo.Def == DamageDefOf.EMP && affectedByEMP)
 	    {


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
