### PR TITLE
Set melee targeting to Vanilla

### DIFF
--- a/Source/CombatExtended/CombatExtended/CollisionVertical.cs
+++ b/Source/CombatExtended/CombatExtended/CollisionVertical.cs
@@ -128,9 +128,10 @@ namespace CombatExtended
             return BodyPartHeight.Top;
         }
 
+        /* Alistaire: Part of code that targets Bottom too often
         public BodyPartHeight GetRandWeightedBodyHeightBelow(float threshold)
         {
             return GetCollisionBodyHeight(Rand.Range(Min, threshold));
-        }
+        }*/
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -249,7 +249,8 @@ namespace CombatExtended
             Vector3 direction = (target.Thing.Position - CasterPawn.Position).ToVector3();
             DamageDef def = damDef;
             //END 1:1 COPY
-            BodyPartHeight bodyRegion = GetBodyPartHeightFor(target);   //Custom // Add check for body height
+            BodyPartHeight bodyRegion = BodyPartHeight.Undefined; //Alistaire: The GetBodyPartHeightFor code is completely broken and targets Bottom some 90% of the time! Therefore easiest fix to set to Vanilla (Undefined)
+                                                                  //GetBodyPartHeightFor(target);   //Custom // Add check for body height
             //START 1:1 COPY
             DamageInfo damageInfo = new DamageInfo(def, damAmount, armorPenetration, -1f, caster, null, source, DamageInfo.SourceCategory.ThingOrUnknown, null); //Alteration
 
@@ -450,6 +451,9 @@ namespace CombatExtended
             }
         }
 
+        /*
+         *  Alistaire: Code targets Bottom about 90% of the time, therefore commented out
+         *  
         /// <summary>
         /// Selects a random BodyPartHeight out of the ones our CasterPawn can hit, depending on our body size vs the target's. So a rabbit can hit top height of another rabbit, but not of a human.
         /// </summary>
@@ -464,7 +468,7 @@ namespace CombatExtended
             BodyPartHeight maxHeight = targetHeight.GetRandWeightedBodyHeightBelow(casterReach);
             BodyPartHeight height = (BodyPartHeight)Rand.RangeInclusive(1, (int)maxHeight);
             return height;
-        }
+        }*/
 
         // unmodified
         private SoundDef SoundHitPawn()


### PR DESCRIPTION
CE version targeted bottom about 90% of the time because of poor randomization code - see #642 for proper calculation of random chance

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
