### PR TITLE
Hard armor damage change

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -220,10 +220,6 @@ namespace CombatExtended
             newPenAmount -= partDensity;    // Factor partDensity only after damage calculations
 
             // Apply damage to armor
-            var fullDeflect = armorAmount > penAmount * 2f;
-            var armorDamagePen = penAmount * 2f - armorAmount;
-            var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
-            var armorDmgAmount = dmgAmount * armorDmgMult;
             if (armor != null)
             {
                 var isSoftArmor = armor.Stuff != null && armor.Stuff.stuffProps.categories.Any(s => softStuffs.Contains(s));
@@ -239,6 +235,10 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
+                    var fullDeflect = armorAmount > penAmount * 2f;
+                    var armorDamagePen = penAmount * 2f - armorAmount;
+                    var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
+                    var armorDmgAmount = dmgAmount * armorDmgMult;
                     var armorDamage = Mathf.Max(0, armorDmgAmount);
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -239,7 +239,7 @@ namespace CombatExtended
                     var armorDamagePen = penAmount * 2f - armorAmount;
                     var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
                     var armorDmgAmount = dmgAmount * armorDmgMult;
-                    var armorDamage = Mathf.Max(0, armorDmgAmount);
+                    var armorDamage = Mathf.Max(1, armorDmgAmount);
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }
             }

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -220,6 +220,10 @@ namespace CombatExtended
             newPenAmount -= partDensity;    // Factor partDensity only after damage calculations
 
             // Apply damage to armor
+            var fullDeflect = armorAmount > penAmount * 2f;
+            var armorDamagePen = penAmount * 2f - armorAmount;
+            var armorDmgMult = fullDeflect ? 0 : penAmount == 0 ? 1 : Mathf.Clamp01(armorDamagePen / penAmount);
+            var armorDmgAmount = dmgAmount * armorDmgMult;
             if (armor != null)
             {
                 var isSoftArmor = armor.Stuff != null && armor.Stuff.stuffProps.categories.Any(s => softStuffs.Contains(s));
@@ -235,7 +239,7 @@ namespace CombatExtended
                 else
                 {
                     // Hard armor takes damage as reduced by damage resistance and can be almost impervious to low-penetration attacks
-                    var armorDamage = Mathf.Max(1, newDmgAmount);
+                    var armorDamage = Mathf.Max(0, armorDmgAmount);
                     armor.TakeDamage(new DamageInfo(def, Mathf.CeilToInt(armorDamage)));
                 }
             }


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
