### PR TITLE
Pa tier cost rebalance

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Hats.xml
@@ -75,7 +75,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_SimpleHelmet"]/costStuffCount</xpath>
     <value>
-      <costStuffCount>50</costStuffCount>
+      <costStuffCount>25</costStuffCount>
     </value>
   </Operation>
 
@@ -186,6 +186,13 @@
       <Flammability>0</Flammability>
     </value>
   </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/statBases/Mass</xpath>
+    <value>
+      <Mass>4.8</Mass>
+    </value>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/statBases/MaxHitPoints</xpath>
@@ -223,7 +230,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetPowerBase"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>45</Plasteel>
+      <Plasteel>80</Plasteel>
       <DevilstrandCloth>20</DevilstrandCloth>
     </value>
   </Operation>
@@ -260,6 +267,13 @@
       <Flammability>0</Flammability>
     </value>
   </Operation>
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/Mass</xpath>
+    <value>
+      <Mass>3.6</Mass>
+    </value>
+  </Operation>
 
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/statBases/MaxHitPoints</xpath>
@@ -294,12 +308,14 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList</xpath>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/costList/Plasteel</xpath>
     <value>
+      <Plasteel>60</Plasteel>
       <DevilstrandCloth>15</DevilstrandCloth>
     </value>
   </Operation>
+
 
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetReconBase"]/apparel/layers</xpath>

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -137,6 +137,15 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+	
+	<!-- Reduce Cost -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_PlateArmor"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>105</costStuffCount>
+		</value>
+	</Operation>
 
 	<!-- ========== Armor vest ========== -->
 
@@ -447,6 +456,22 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+	
+	<!-- Increase Cost -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>225</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorPowerBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>40</Uranium>
+		</value>
+	</Operation>
 
 	<!-- ========== Recon armor ========== -->
 
@@ -517,6 +542,22 @@
 		<value>
 			<li>Hands</li>
 			<li>Feet</li>
+		</value>
+	</Operation>
+	
+	<!-- Increase Cost -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>180</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorReconBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>20</Uranium>
 		</value>
 	</Operation>
 

--- a/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
+++ b/Patches/JDS Exiled Dawn/Thingdefs_Misc/Apparel.xml
@@ -14,7 +14,7 @@
 				<xpath>Defs/ThingDef[@Name="JDSExiledChestPlate(AR)ArmorBase" or 
 				@Name="JDSExiledChestPlateArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>8</ArmorRating_Sharp>
+					<ArmorRating_Sharp>9.6</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -22,7 +22,7 @@
 				<xpath>Defs/ThingDef[@Name="JDSExiledChestPlate(AR)ArmorBase" or 
 				@Name="JDSExiledChestPlateArmorBase"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>24</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -155,7 +155,7 @@
 				</value>
 			</li>
 			
-			<!--Plate Gambeson-->
+			<!--Plate Gambeson : Stronger in vanilla but costs less. No idea why.-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledPlateGambesonARArmorBase" or 
@@ -204,12 +204,12 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--King Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledKingArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -237,12 +237,12 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--Knight Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledKnightArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -270,12 +270,12 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--Knight Captain Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledKnightCaptainArmorBase"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>24</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -303,7 +303,20 @@
 				</value>
 			</li>
 			
-			<!-- -->
+			<!--Price Change-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Colored_King_Armor" or
+				defName="Colored_Knight_Armor" or
+				defName="Colored_Knight_Captain"
+				]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>240</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<!--Scholar Armor-->
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[@Name="JDSExiledScholarArmorBase"]/statBases/ArmorRating_Sharp</xpath>
@@ -333,6 +346,18 @@
 				<value>
 					<CarryBulk>10</CarryBulk>
 					<CarryWeight>60</CarryWeight>
+				</value>
+			</li>
+			
+			<!--Price Change-->
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Colored_Scholar_Armor"
+				]/costList/Steel</xpath>
+				<value>
+					<Plasteel>120</Plasteel>
+					<Steel>250</Steel>
+					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
+++ b/Patches/PowerArmour T-45b/T45b_CE_Patch.xml
@@ -52,6 +52,13 @@
 					</value>
 				</li>
 				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bHelmet"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>70</Plasteel>
+					</value>
+				</li>
+				
 				<!-- Deliberately omitted WearingGasMask ApparelHediffExtension, as we assume the T-45b Helmet is more comfortable than real-life gas masks -->
 				
 				<!-- ========== T-45b armor ========== -->
@@ -97,6 +104,13 @@
 					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/statBases</xpath>
 					<value>
 						<ArmorRating_Electric>0.05</ArmorRating_Electric>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="CPApparel_T45bPowerArmor"]/costList/Plasteel</xpath>
+					<value>
+						<Plasteel>200</Plasteel>
 					</value>
 				</li>
 

--- a/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
+++ b/Patches/PsiTech/ThingDefs/Equipment/PsiTechAdvancedApparel.xml
@@ -55,9 +55,10 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicCommandoArmor"]/costList/Plasteel</xpath>
 					<value>
+						<Plasteel>255</Plasteel>
 						<DevilstrandCloth>60</DevilstrandCloth>
 					</value>
 				</li>
@@ -101,7 +102,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/statBases/Mass</xpath>
 					<value>
-						<Mass>1.6</Mass>
+						<Mass>5.2</Mass>
 					</value>
 				</li>
 				<!-- equippedStatOffsets -->
@@ -117,7 +118,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicCommandoHelmet"]/costList/Plasteel</xpath>
 					<value>
-						<Plasteel>45</Plasteel>
+						<Plasteel>90</Plasteel>
 						<DevilstrandCloth>30</DevilstrandCloth>
 					</value>
 				</li>
@@ -179,10 +180,11 @@
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicWarriorArmor"]/costList/Plasteel</xpath>
 					<value>
-						<DevilstrandCloth>50</DevilstrandCloth>
+						<Plasteel>225</Plasteel>
+						<DevilstrandCloth>60</DevilstrandCloth>
 					</value>
 				</li>
 				<!-- apparel -->
@@ -225,7 +227,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/statBases/Mass</xpath>
 					<value>
-						<Mass>1.2</Mass>
+						<Mass>4.8</Mass>
 					</value>
 				</li>
 				<!-- equippedStatOffsets -->
@@ -238,9 +240,10 @@
 					</value>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicWarriorHelmet"]/costList/Plasteel</xpath>
 					<value>
+						<Plasteel>80</Plasteel>
 						<DevilstrandCloth>20</DevilstrandCloth>
 					</value>
 				</li>
@@ -299,10 +302,11 @@
 					</value>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicConduitArmor"]/costList/Plasteel</xpath>
 					<value>
-						<DevilstrandCloth>45</DevilstrandCloth>
+						<Plasteel>180</Plasteel>
+						<DevilstrandCloth>50</DevilstrandCloth>
 					</value>
 				</li>
 				<!-- apparel -->
@@ -358,9 +362,10 @@
 					</value>
 				</li>
 				<!-- costList -->
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/costList</xpath>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="PTPsionicConduitHelmet"]/costList/Plasteel</xpath>
 					<value>
+						<Plasteel>60</Plasteel>
 						<DevilstrandCloth>15</DevilstrandCloth>
 					</value>
 				</li>

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelBodyArmour.xml
@@ -13,18 +13,26 @@
 		<operations>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/Mass</xpath>
 				<value>
-					<ArmorRating_Sharp>20.50</ArmorRating_Sharp>
+					<Mass>50</Mass>
 					<Bulk>100</Bulk>
 					<WornBulk>15</WornBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>21</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.45</ArmorRating_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>38</ArmorRating_Blunt>
+					<ArmorRating_Blunt>47.25</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -32,8 +40,16 @@
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
-					<CarryWeight>60</CarryWeight>
+					<CarryWeight>85</CarryWeight>
 					<CarryBulk>20</CarryBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorBodyArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>240</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
+++ b/Patches/Rim Contractors Arsenal/ThingDefs_Misc/ApparelHeadgear.xml
@@ -15,7 +15,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18.85</ArmorRating_Sharp>
+					<ArmorRating_Sharp>19</ArmorRating_Sharp>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
 				</value>
@@ -24,7 +24,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>42.75</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -33,6 +33,14 @@
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 					<AimingAccuracy>0.10</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_ContractorArmorHelmet"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>85</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
+++ b/Patches/Rimsenal Collection/Core/Apparel_RS_CE.xml
@@ -61,28 +61,36 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>17</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>38</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList</xpath>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>100</Plasteel>
 					<DevilstrandCloth>35</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList/Steel</xpath>
+				<value>
+					<Steel>160</Steel>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>60</CarryWeight>
+					<CarryWeight>45</CarryWeight>
 					<CarryBulk>15</CarryBulk>
 				</value>
 			</li>
@@ -109,14 +117,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -124,6 +132,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>30</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -138,13 +154,23 @@
 			
 			<!-- ========== Drop Suit =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/Mass</xpath>
 				<value>
+					<Mass>60</Mass>
 					<Bulk>90</Bulk>
-					<WornBulk>12</WornBulk>
+					<WornBulk>18</WornBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>225</Plasteel>
+					<DevilstrandCloth>40</DevilstrandCloth>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -156,7 +182,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>15</CarryWeight>
+					<CarryWeight>90</CarryWeight>
 					<CarryBulk>8</CarryBulk>
 				</value>
 			</li>
@@ -164,23 +190,24 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>17</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>51</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<!-- ========== Dropsuit Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases/Mass</xpath>
 				<value>
 					<Bulk>5</Bulk>
+					<Mass>5</Mass>
 					<WornBulk>1</WornBulk>
 				</value>
 			</li>
@@ -188,14 +215,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>42</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -203,6 +230,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_DropsuitH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>75</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -217,11 +252,12 @@
 			
 			<!-- ========== Nervesuit =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>80</Bulk>
-					<WornBulk>8</WornBulk>
+					<Bulk>75</Bulk>
+					<Mass>20</Mass>
+					<WornBulk>10</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
@@ -234,22 +270,30 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>10</CarryWeight>
-					<CarryBulk>5</CarryBulk>
+					<CarryWeight>50</CarryWeight>
+					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>150</Plasteel>
+					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>23</ArmorRating_Blunt>
+					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 				</value>
 			</li>	
 			
@@ -274,7 +318,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>18</ArmorRating_Blunt>
+					<ArmorRating_Blunt>22.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -283,6 +327,14 @@
 				<value>
 					<Suppressability>-0.25</Suppressability>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>45</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -296,39 +348,52 @@
 			</li>
 			
 			<!-- ========== Assault Armor =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases</xpath>
-				<value>
-					<Bulk>120</Bulk>
-					<WornBulk>20</WornBulk>
-				</value>
-			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>60</Mass>
+					<Mass>100</Mass>
+					<Bulk>120</Bulk>
+					<WornBulk>30</WornBulk>
 				</value>
 			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					<ArmorRating_Sharp>28</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>58.5</ArmorRating_Blunt>
+					<ArmorRating_Blunt>70</ArmorRating_Blunt>
 				</value>
-			</li>			
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>40</CarryWeight>
-					<CarryBulk>10</CarryBulk>
+					<CarryWeight>95</CarryWeight>
+					<CarryBulk>5</CarryBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>280</Plasteel>
+					<DevilstrandCloth>60</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>90</Uranium>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -390,23 +455,24 @@
 			
 			<!-- ========== Assault Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>8</Bulk>
-					<WornBulk>2</WornBulk>
+					<Mass>10</Mass>
+					<Bulk>20</Bulk>
+					<WornBulk>10</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>25</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>45</ArmorRating_Blunt>
+					<ArmorRating_Blunt>62.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			
@@ -414,6 +480,15 @@
 				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>90</Plasteel>
+					<Uranium>20</Uranium>
+					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -427,18 +502,13 @@
 			</li>
 			
 			<!-- ========== Fire Support Armor =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/statBases</xpath>
-				<value>
-					<Bulk>80</Bulk>
-					<WornBulk>15</WornBulk>
-				</value>
-			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>55</Mass>
+					<Mass>70</Mass>
+					<Bulk>80</Bulk>
+					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -450,16 +520,33 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 				</value>
 			</li>			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>90</CarryWeight>
-					<CarryBulk>40</CarryBulk>
+					<CarryWeight>120</CarryWeight>
+					<CarryBulk>50</CarryBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/equippedStatOffsets/AimingDelayFactor</xpath>
+				<value>
+					<AimingDelayFactor>-0.25</AimingDelayFactor>
+					<ReloadSpeed>0.5</ReloadSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>220</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -468,12 +555,13 @@
 				</value>
 			</li>
 			<!-- ========== Fire Support Helmet =========== -->
-
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/statBases</xpath>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/statBases/Mass</xpath>
 				<value>
+					<Mass>5</Mass>
 					<Bulk>7</Bulk>
-					<WornBulk>1.5</WornBulk>
+					<WornBulk>5</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -485,7 +573,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -493,6 +581,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_FSArmorH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>70</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -507,23 +603,18 @@
 			
 			<!-- ========== Reflactor Carapace =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases</xpath>
-				<value>
-					<Bulk>100</Bulk>
-					<WornBulk>15</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>50</Mass>
+					<Mass>60</Mass>
+					<Bulk>100</Bulk>
+					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>20</ArmorRating_Sharp>
+					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -535,14 +626,29 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>42</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/equippedStatOffsets</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>40</CarryWeight>
+					<CarryWeight>100</CarryWeight>
 					<CarryBulk>10</CarryBulk>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>200</Plasteel>
+					<DevilstrandCloth>75</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>60</Uranium>
 				</value>
 			</li>
 
@@ -556,17 +662,18 @@
 
 			<!-- ========== Reflactor Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1.1</WornBulk>
+					<Mass>5.2</Mass>
+					<Bulk>6</Bulk>
+					<WornBulk>1.5</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>15</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -578,7 +685,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>37.5</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -588,6 +695,21 @@
 					<equippedStatOffsets>
 						<SmokeSensitivity>-1</SmokeSensitivity>
 					</equippedStatOffsets>	
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>75</Plasteel>
+					<DevilstrandCloth>30</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>20</Uranium>
 				</value>
 			</li>
 			
@@ -602,23 +724,18 @@
 			
 			<!-- ========== Hazard Carapace =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases</xpath>
-				<value>
-					<Bulk>100</Bulk>
-					<WornBulk>18</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases/Mass</xpath>
 				<value>
-					<Mass>55</Mass>
+					<Mass>65</Mass>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -630,14 +747,29 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/statBases/ArmorRating_Heat</xpath>
 				<value>
-					<ArmorRating_Heat>1.4</ArmorRating_Heat>
+					<ArmorRating_Heat>1</ArmorRating_Heat>
+					<ArmorRating_Electric>1</ArmorRating_Electric>
 				</value>
 			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/equippedStatOffsets</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>45</CarryWeight>
+					<CarryWeight>90</CarryWeight>
 					<CarryBulk>25</CarryBulk>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>180</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapace"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>80</Uranium>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
@@ -650,23 +782,24 @@
 
 			<!-- ========== Hazard Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1.0</WornBulk>
+					<Mass>6</Mass>
+					<Bulk>6</Bulk>
+					<WornBulk>1</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>19</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					<ArmorRating_Blunt>31.5</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -683,6 +816,21 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>60</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>30</Uranium>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_HazardCarapaceH"]/apparel/layers</xpath>
 				<value>
@@ -694,44 +842,50 @@
 
 			<!-- ========== CQ Armor =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases</xpath>
-				<value>
-					<Bulk>65</Bulk>
-					<WornBulk>12</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/Mass</xpath>
 				<value>
-					<Mass>30</Mass>
+					<Mass>60</Mass>
+					<Bulk>65</Bulk>
+					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>16</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Heat</xpath>
-				<value>
-					<ArmorRating_Heat>0.7</ArmorRating_Heat>
-				</value>
-			</li>
+			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>40</CarryWeight>
+					<CarryWeight>80</CarryWeight>
 					<CarryBulk>20</CarryBulk>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>180</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/costList/Uranium</xpath>
+				<value>
+					<Uranium>140</Uranium>
+				</value>
+			</li>
+			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
@@ -739,6 +893,7 @@
 					<li>Feet</li>
 				</value>
 			</li>
+			
 			
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatArmor"]/equippedStatOffsets/MeleeDodgeChance</xpath>
@@ -751,29 +906,24 @@
 
 			<!-- ========== CQ Helmet =========== -->
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/Mass</xpath>
 				<value>
+					<Mass>5</Mass>
 					<Bulk>5</Bulk>
-					<WornBulk>1.0</WornBulk>
+					<WornBulk>1</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Heat</xpath>
-				<value>
-					<ArmorRating_Heat>0.85</ArmorRating_Heat>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>32</ArmorRating_Blunt>
+					<ArmorRating_Blunt>54</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -781,6 +931,14 @@
 				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/thingDef[defName="Apparel_CloseCombatHelmet"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>80</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
+++ b/Patches/Rimsenal Collection/Federation/ThingDefs_Misc/Fed_Apparel.xml
@@ -44,10 +44,11 @@
 			</li>	
 		
 			<!-- ========== Riot Armor =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>40</Bulk>
+					<Bulk>100</Bulk>
+					<Mass>60</Mass>
 					<WornBulk>10</WornBulk>
 				</value>
 			</li>
@@ -55,7 +56,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>5</CarryWeight>
+					<CarryWeight>80</CarryWeight>
 				</value>
 			</li>
 
@@ -71,20 +72,30 @@
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>28</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.75</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>40</ArmorRating_Blunt>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_Judicator"]/costList/Foerum</xpath>
+				<value>
+					<Foerum>240</Foerum>
+					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
 
 			<!-- ========== Riot Helmet =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases/Mass</xpath>
 				<value>
+					<Mass>5</Mass>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
 				</value>
@@ -94,13 +105,29 @@
 				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>26</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.70</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>37.15</ArmorRating_Blunt>
+					<ArmorRating_Blunt>26</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_JudicatorH"]/costList/Foerum</xpath>
+				<value>
+					<Foerum>90</Foerum>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			
@@ -114,19 +141,20 @@
 			</li>
 		
 			<!-- ========== Marksman Armor =========== -->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>20</Bulk>
-					<WornBulk>3</WornBulk>
+					<Mass>15</Mass>
+					<Bulk>40</Bulk>
+					<WornBulk>10</WornBulk>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>5</CarryWeight>
-					<CarryBulk>4</CarryBulk>
+					<CarryWeight>20</CarryWeight>
+					<CarryBulk>15</CarryBulk>
 				</value>
 			</li>
 
@@ -141,14 +169,15 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.20</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGear"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
 				</value>
 			</li>
 
@@ -165,13 +194,21 @@
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.20</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>20</ArmorRating_Blunt>
+					<ArmorRating_Blunt>5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Apparel_MarksmanGearH"]/equippedStatOffsets</xpath>
+				<value>
+					<SmokeSensitivity>-0.75</SmokeSensitivity>
 				</value>
 			</li>
 			
@@ -186,18 +223,18 @@
 
 			<!-- ========== Unity Guard Armor =========== -->
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases/Mass</xpath>
 				<value>
-					<Bulk>10</Bulk>
+					<Bulk>15</Bulk>
 					<WornBulk>5</WornBulk>
+					<Mass>11</Mass>
 				</value>
 			</li>
 
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/equippedStatOffsets</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>4</CarryWeight>
-					<CarryBulk>5</CarryBulk>
+					<CarryBulk>10</CarryBulk>
 				</value>
 			</li>
 
@@ -212,13 +249,14 @@
 				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_UGCuirass"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>12</ArmorRating_Blunt>
+					<ArmorRating_Blunt>10</ArmorRating_Blunt>
 				</value>
 			</li>
 		
@@ -234,14 +272,15 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>14</ArmorRating_Sharp>
+					<ArmorRating_Sharp>11</ArmorRating_Sharp>
+					<ArmorRating_Electric>0.30</ArmorRating_Electric>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_UGHelmet"]/statBases</xpath>
 				<value>
-					<ArmorRating_Blunt>10</ArmorRating_Blunt>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
 				</value>
 			</li>
 			

--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -93,13 +93,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExoH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>28</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExoH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15</ArmorRating_Sharp>
+					<ArmorRating_Sharp>14</ArmorRating_Sharp>
 				</value>
 			</li>
 			
@@ -110,7 +110,13 @@
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
 			</li>
-			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>46</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
+				</value>
+			</li>		
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExoH"]/apparel/layers</xpath>
 				<value>
@@ -182,13 +188,13 @@
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/statBases</xpath>
 				<value>
 					<Bulk>110</Bulk>
-					<WornBulk>18</WornBulk>					
+					<WornBulk>25</WornBulk>					
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/Mass</xpath>
 				<value>
-					<Mass>60</Mass>		
+					<Mass>75</Mass>		
 				</value>
 			</li>					
 			<li Class="PatchOperationAdd">
@@ -199,22 +205,29 @@
 					<ToxicSensitivity>-0.45</ToxicSensitivity>
 			</value>
 		    </li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>104</Plasteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
-			</li>			
+			</li>		
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Apparel_FeralExo"]/costList/Steel</xpath>
+				<value>
+					<Steel>256</Steel>
+				</value>
+			</li>	
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>36</ArmorRating_Blunt>
+					<ArmorRating_Blunt>32</ArmorRating_Blunt>
 				</value>			
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="Apparel_FeralExo"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>18</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Armor.xml
@@ -74,6 +74,20 @@
 			<li>Feet</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorCataphractBase"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>315</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ApparelArmorCataphractBase"]/costList/Uranium</xpath>
+		<value>
+			<Uranium>80</Uranium>
+		</value>
+	</Operation>
 
 
     <!-- Grenadier armor -->
@@ -266,7 +280,36 @@
             <JumpRange>30</JumpRange>
         </value>
     </Operation>
-
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorLocust"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>220</Plasteel>
+		</value>
+	</Operation>
+	
+	<!-- ========== Prestige Armor ========== -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorReconPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>200</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorMarinePrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>245</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>335</Plasteel>
+		</value>
+	</Operation>
 
 </Patch>
 

--- a/Royalty/Patches/ThingDefs_Misc/Apparel_Headgear.xml
+++ b/Royalty/Patches/ThingDefs_Misc/Apparel_Headgear.xml
@@ -150,6 +150,13 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/statBases/Mass</xpath>
+    <value>
+      <Mass>6.6</Mass>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/statBases/MaxHitPoints</xpath>
     <value>
       <MaxHitPoints>260</MaxHitPoints>
@@ -182,10 +189,11 @@
     </value>
   </Operation>
 
-  <Operation Class="PatchOperationAdd">
-    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/costList</xpath>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[@Name="ApparelArmorHelmetCataphractBase"]/costList/Plasteel</xpath>
     <value>
-      <DevilstrandCloth>30</DevilstrandCloth>
+      <Plasteel>110</Plasteel>
+      <DevilstrandCloth>25</DevilstrandCloth>
     </value>
   </Operation>
 
@@ -197,6 +205,29 @@
       <li>MiddleHead</li>
     </value>
   </Operation>
+  
+	<!-- ========== Prestige Armor ========== -->
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetReconPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>70</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorMarineHelmetPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>90</Plasteel>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetCataphractPrestige"]/costList/Plasteel</xpath>
+		<value>
+			<Plasteel>120</Plasteel>
+		</value>
+	</Operation>
 
 </Patch>
 


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
