### PR TITLE
Breadbox2k19 mech tweak

### DIFF
--- a/Patches/Core/FactionDefs/Factions_Misc.xml
+++ b/Patches/Core/FactionDefs/Factions_Misc.xml
@@ -28,7 +28,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/FactionDef[defName="Mechanoid"]/pawnGroupMakers/li[1]/options/Mech_Centipede</xpath>
     <value>
-      <Mech_Centipede>50</Mech_Centipede>
+      <Mech_Centipede>40</Mech_Centipede>
     </value>
   </Operation>
 

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -16,6 +16,13 @@
   		<combatPower>580</combatPower>
   	</value>
   </Operation>
+
+  <Operation Class="PatchOperationReplace">
+  	<xpath>Defs/PawnKindDef[defName="Mech_Scyther" or defName="Mech_Lancer"]/combatPower</xpath>
+  	<value>
+  		<combatPower>110</combatPower>
+  	</value>
+  </Operation>
 <!--
   <Operation Class="PatchOperationAdd">
     <xpath>Defs/PawnKindDef[defName="Mech_Centipede"]</xpath>
@@ -25,24 +32,12 @@
   </Operation>
 -->
   <Operation Class="PatchOperationAddModExtension">
-  	<xpath>Defs/PawnKindDef[defName="Mech_Lancer"]</xpath>
+  	<xpath>Defs/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Centipede"]</xpath>
   	<value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>
-          <min>100</min>
-          <max>100</max>
-        </primaryMagazineCount>
-      </li>
-  	</value>
-  </Operation>
-  
-  <Operation Class="PatchOperationAddModExtension">
-  	<xpath>Defs/PawnKindDef[defName="Mech_Centipede"]</xpath>
-  	<value>
-      <li Class="CombatExtended.LoadoutPropertiesExtension">
-        <primaryMagazineCount>
-          <min>10</min>
-          <max>12</max>
+          <min>9</min>
+          <max>10</max>
         </primaryMagazineCount>
       </li>
   	</value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1263,7 +1263,7 @@
       <verbClass>CombatExtended.Verb_ShootCE</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
-      <warmupTime>1.3</warmupTime>
+      <warmupTime>1.2</warmupTime>
       <range>62</range>
       <burstShotCount>1</burstShotCount>
       <soundCast>ChargeLance_Fire</soundCast>
@@ -1271,8 +1271,8 @@
       <muzzleFlashScale>9</muzzleFlashScale>
     </Properties>
     <AmmoUser>
-      <magazineSize>1</magazineSize>
-      <reloadTime>1.6</reloadTime>
+      <magazineSize>5</magazineSize>
+      <reloadTime>2.5</reloadTime>
       <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
     </AmmoUser>
     <FireModes>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
