### PR TITLE
Breadbox2k19 erin

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_Projectiles.xml
@@ -24,14 +24,13 @@
 				defName="AA_RedPoisonBolt" or
 				defName="AA_Web" or
 				defName="AA_FireSpit" or
-				defName="AA_AcidicVomit" or
 				defName="AA_DarkBolt" or
 				defName="AA_AcidBolt"]</xpath>
 					<value>
 						<thingClass>CombatExtended.BulletCE</thingClass>
 					</value>
 				</li>
-
+				
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/VFECore.ExpandableProjectileDef[defName="AA_LaserBullet"]/thingClass</xpath>
 					<value>
@@ -122,6 +121,24 @@
           										<chance>0.5</chance>
 									</li>
 								</secondaryDamage>
+							</projectile>
+						</ThingDef>
+						
+						<ThingDef ParentName="BaseBullet">
+							<defName>AA_AcidicVomit_CE</defName>
+							<label>acidic vomit</label>
+							<thingClass>CombatExtended.BulletCE</thingClass>
+							<graphicData>
+								<texPath>Things/Projectiles/Proj_LiquidStream</texPath>	
+								<graphicClass>Graphic_Flicker</graphicClass>
+								<shaderType>MoteGlow</shaderType>
+							</graphicData>
+							<projectile Class="CombatExtended.ProjectilePropertiesCE">
+								<damageDef>AA_AcidSpit</damageDef>		
+								<flyOverhead>false</flyOverhead>
+								<damageAmountBase>15</damageAmountBase>
+								<armorPenetrationBlunt>0.5</armorPenetrationBlunt>		
+								<speed>18</speed>
 							</projectile>
 						</ThingDef>
 					</value>
@@ -296,18 +313,7 @@
 						</projectile>
 					</value>
 				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>/Defs/VFECore.ExpandableProjectileDef[defName="AA_AcidicVomit"]/projectile</xpath>
-					<value>
-						<projectile Class="CombatExtended.ProjectilePropertiesCE">
-							<damageDef>AA_AcidSpit</damageDef>
-							<flyOverhead>false</flyOverhead>
-							<damageAmountBase>12</damageAmountBase>
-							<speed>9</speed>
-							<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
-						</projectile>
-					</value>
-				</li>
+
 				<!-- ======== Note: AA_ExplodingWeb wasn't used in any Race, so it wasn't included. If it gets added, just add a secondaryDamage to the corresponding projectile, with the Bomb damageDef ======== -->
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_Web"]/projectile</xpath>

--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_VerbShootCE.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_VerbShootCE.xml
@@ -687,8 +687,8 @@
 									<li Class="CombatExtended.VerbPropertiesCE">
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 										<hasStandardCommand>true</hasStandardCommand>
-										<defaultProjectile>AA_AcidicVomit</defaultProjectile>
-										<warmupTime>2.5</warmupTime>
+										<defaultProjectile>AA_AcidicVomit_CE</defaultProjectile>
+										<warmupTime>2.6</warmupTime>
 										<burstShotCount>1</burstShotCount>
 										<minRange>1</minRange>
 										<range>8</range>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
