### PR TITLE
Make caravans carry less explosive shells.

### DIFF
--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -58,6 +58,12 @@
     <techLevel>Spacer</techLevel>
   </ThingDef>
 	
+  <ThingDef Class="CombatExtended.AmmoDef" Name="HeavyAmmoBase" ParentName="AmmoBase" Abstract="True">
+		<tradeTags inherit="false">
+		  <li>CE_HeavyAmmo</li>
+		</tradeTags>
+  </ThingDef>
+
 	<!-- ================== Projectiles ================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="BaseBullet" Abstract="True">

--- a/Defs/Ammo/Shell/100x695mmR.xml
+++ b/Defs/Ammo/Shell/100x695mmR.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="100x695mmRCannonShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="100x695mmRCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large cannon shells, typically used by D-10 tank guns.</description>
 		<thingCategories>
 			<li>Ammo100x695mmRCannonShells</li>

--- a/Defs/Ammo/Shell/120mmCannon.xml
+++ b/Defs/Ammo/Shell/120mmCannon.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="120mmCannonShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="120mmCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large cannon shells, typically used by 120mm smoothbore tank guns.</description>
 		<thingCategories>
 			<li>Ammo120mmCannonShells</li>

--- a/Defs/Ammo/Shell/155mmHowitzer.xml
+++ b/Defs/Ammo/Shell/155mmHowitzer.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="155mmHowitzerShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="155mmHowitzerShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large cannon shell used by howitzers.</description>
 		<thingCategories>
 			<li>Ammo155mmHowitzerShells</li>

--- a/Defs/Ammo/Shell/28cmSpgr.xml
+++ b/Defs/Ammo/Shell/28cmSpgr.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="28cmSpgrShellBase" ParentName="AmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="28cmSpgrShellBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Very large obsolete cannon shell used in naval battleship turrets.</description>
 		<thingCategories>
 			<li>Ammo28cmSpgrShells</li>

--- a/Defs/Ammo/Shell/40x365mmBofors.xml
+++ b/Defs/Ammo/Shell/40x365mmBofors.xml
@@ -21,7 +21,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo40x365mmBoforsBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo40x365mmBoforsBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by autocannons and anti-aircraft cannons.</description>
 		<statBases>
 			<Mass>2.15</Mass>

--- a/Defs/Ammo/Shell/50mmType89Mortar.xml
+++ b/Defs/Ammo/Shell/50mmType89Mortar.xml
@@ -20,7 +20,7 @@
 	
 	<!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="50mmType89MortarShellBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="50mmType89MortarShellBase" ParentName="HeavyAmmoBase" Abstract="True">
     <description>Low-velocity shell designed to be fired from a mortar.</description>
     <thingCategories>
       <li>Ammo50mmType89MortarShells</li>

--- a/Defs/Ammo/Shell/57x483mmBofors.xml
+++ b/Defs/Ammo/Shell/57x483mmBofors.xml
@@ -20,7 +20,7 @@
 
 	<!-- ==================== Ammo ========================== -->
 
-	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo57x483mmBoforsBase" ParentName="SmallAmmoBase" Abstract="True">
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo57x483mmBoforsBase" ParentName="HeavyAmmoBase" Abstract="True">
 		<description>Large caliber cartridge used by naval artillery cannons.</description>
 		<thingCategories>
 			<li>Ammo57x483mmBofors</li>

--- a/Defs/Ammo/Shell/60mmMortar.xml
+++ b/Defs/Ammo/Shell/60mmMortar.xml
@@ -28,7 +28,7 @@
   <!-- ==================== Ammo ========================== -->
 
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="60mmMortarShellBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="60mmMortarShellBase" ParentName="HeavyAmmoBase" Abstract="True">
     <description>Low-velocity shell designed to be fired from a mortar.</description>
     <graphicData>
       <drawSize>0.80</drawSize>

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -30,7 +30,7 @@
   <!-- ==================== Ammo ========================== -->
 
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="81mmMortarShellBase" ParentName="HeavyAmmoBase" Abstract="True">
     <description>Low-velocity shell designed to be fired from a mortar.</description>
     <statBases>
       <MaxHitPoints>200</MaxHitPoints>

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -23,7 +23,7 @@
 
   <!-- ==================== Ammo ========================== -->
 
-  <ThingDef Class="CombatExtended.AmmoDef" Name="90mmCannonShellBase" ParentName="AmmoBase" Abstract="True">
+  <ThingDef Class="CombatExtended.AmmoDef" Name="90mmCannonShellBase" ParentName="HeavyAmmoBase" Abstract="True">
     <description>Relatively small cannon shell.</description>
     <thingCategories>
       <li>Ammo90mmCannonShells</li>

--- a/Patches/Core/TraderKindDefs/TraderKinds.xml
+++ b/Patches/Core/TraderKindDefs/TraderKinds.xml
@@ -201,6 +201,17 @@
           <max>9</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>6</max>
+        </thingDefCountRange>
+      </li>      
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -263,6 +274,17 @@
           <max>4</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>5</min>
+          <max>20</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>3</max>
+        </thingDefCountRange>
+      </li>         
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -324,6 +346,18 @@
           <max>8</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>10</min>
+          <max>50</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>2</min>
+          <max>5</max>
+        </thingDefCountRange>
+      </li>      
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -386,6 +420,17 @@
           <max>4</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>15</min>
+          <max>100</max>
+        </countRange>
+        <thingDefCountRange>
+          <min>1</min>
+          <max>3</max>
+        </thingDefCountRange>
+      </li>            
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>
@@ -447,6 +492,18 @@
           <max>12</max>
         </thingDefCountRange>
       </li>
+      <li Class="StockGenerator_Tag">
+        <tradeTag>CE_HeavyAmmo</tradeTag>
+        <countRange>
+          <min>100</min>
+          <max>500</max>
+        </countRange>
+        <price>Cheap</price>
+        <thingDefCountRange>
+          <min>3</min>
+          <max>8</max>
+        </thingDefCountRange>
+      </li>       
       <li Class="StockGenerator_Category">
         <categoryDef>Ammo</categoryDef>
         <thingDefCountRange>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
