### PR TITLE
Pa tier cost rebalance

### DIFF
--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Apparel.xml
@@ -297,9 +297,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_DDgear"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>240</Moyo_Abyssteel>
 					<DevilstrandCloth>40</DevilstrandCloth>
 				</value>
 			</li>
@@ -359,9 +360,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_DDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>80</Moyo_Abyssteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -428,9 +430,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_LDgear"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_LDgear"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>190</Moyo_Abyssteel>
 					<DevilstrandCloth>30</DevilstrandCloth>
 				</value>
 			</li>
@@ -484,9 +487,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_LDhelmet"]/costList/Moyo_Abyssteel</xpath>
 				<value>
+					<Moyo_Abyssteel>65</Moyo_Abyssteel>
 					<DevilstrandCloth>15</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
+++ b/Patches/Moyo from the depth/ThingDefs_Misc/Moyo_Royal_Apparel.xml
@@ -142,6 +142,13 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GDsuit"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>325</Moyo_Abyssteel>
+				</value>
+			</li>
+			
 			<!--Royal Guard Helmet-->
 			
 			<li Class="PatchOperationAdd">
@@ -196,6 +203,14 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GDhelmet"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>115</Moyo_Abyssteel>
+					<Hyperweave>10</Hyperweave>
+				</value>
+			</li>
+			
 			<!--Royal Guard Light Armor-->
 			
 			<li Class="PatchOperationAdd">
@@ -243,6 +258,13 @@
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
 					<MoveSpeed>0.1</MoveSpeed>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GSsuit"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>190</Moyo_Abyssteel>
 				</value>
 			</li>
 			
@@ -297,6 +319,14 @@
 				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				<value>
 					<AimingAccuracy>0.10</AimingAccuracy>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Moyo_GShelmet"]/costList/Moyo_Abyssteel</xpath>
+				<value>
+					<Moyo_Abyssteel>100</Moyo_Abyssteel>
+					<Hyperweave>10</Hyperweave>
 				</value>
 			</li>
 			

--- a/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
+++ b/Patches/Neclose Race/ThingDefs_Misc/Neclose_Apparel.xml
@@ -253,9 +253,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_NC_Heads_b"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>75</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>

--- a/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
+++ b/Patches/Rabbie The Moonrabbit/ThingDefs_Misc/RB_Apparel.xml
@@ -384,6 +384,14 @@
 				</value>
 			</li>
 			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RB_RegularInfantrySuit"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>240</Plasteel>
+					<DevilstrandCloth>50</DevilstrandCloth>
+				</value>
+			</li>
+			
 			<!--Regular Army Helmet, 10mm Power Armor-->
 			
 			<li Class="PatchOperationAdd">
@@ -416,6 +424,14 @@
 					<AimingAccuracy>0.15</AimingAccuracy>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
 					<SmokeSensitivity>-1</SmokeSensitivity>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="RB_RegularInfantryhelmet"]/costList/Plasteel</xpath>
+				<value>
+					<Plasteel>100</Plasteel>
+					<DevilstrandCloth>25</DevilstrandCloth>
 				</value>
 			</li>
 			

--- a/Patches/Save Our Ship 2/Apparel_SOS2.xml
+++ b/Patches/Save Our Ship 2/Apparel_SOS2.xml
@@ -104,7 +104,7 @@
     <li Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitHelmetHeavy"]/costList/Plasteel</xpath>
     <value>
-      <Plasteel>50</Plasteel>
+      <Plasteel>80</Plasteel>
       <DevilstrandCloth>20</DevilstrandCloth>
     </value>
    </li>
@@ -133,12 +133,13 @@
 		</li>
 			
 	<!--  Heavy EVA Suit -->
-		<li Class="PatchOperationAdd">
-		      <xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList</xpath>
-		      <value>
-			 <DevilstrandCloth>50</DevilstrandCloth>
-		      </value>
-		</li>
+		<li Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/costList/Plasteel</xpath>
+		<value>
+		  <Plasteel>285</Plasteel>
+		  <DevilstrandCloth>20</DevilstrandCloth>
+		</value>
+	   </li>
 			
 		<li Class="PatchOperationReplace">
 			<xpath>Defs/ThingDef[defName="Apparel_SpaceSuitBodyHeavy"]/statBases/ArmorRating_Sharp</xpath>

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Xenoorca_Apparel.xml
@@ -83,7 +83,7 @@
 				defName="HAR_XO_AM_a"
 				]/equippedStatOffsets/MoveSpeed</xpath>
 				<value>
-					<CarryWeight>70</CarryWeight>
+					<CarryWeight>80</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
@@ -98,9 +98,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AM_a"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AM_a"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>200</Plasteel>
 					<DevilstrandCloth>50</DevilstrandCloth>
 				</value>
 			</li>
@@ -130,7 +131,7 @@
 				defName="HAR_XO_AM_b"
 				]/statBases/Mass</xpath>
 				<value>
-					<Mass>35</Mass>
+					<Mass>25</Mass>
 				</value>
 			</li>
 			
@@ -139,7 +140,7 @@
 				defName="HAR_XO_AM_b"
 				]/equippedStatOffsets</xpath>
 				<value>
-					<CarryWeight>55</CarryWeight>
+					<CarryWeight>45</CarryWeight>
 					<CarryBulk>12</CarryBulk>
 					<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 					<ToxicSensitivity>-0.50</ToxicSensitivity>
@@ -154,10 +155,11 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AM_b"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AM_b"]/costList/Plasteel</xpath>
 				<value>
-					<DevilstrandCloth>30</DevilstrandCloth>
+					<Plasteel>160</Plasteel>
+					<DevilstrandCloth>20</DevilstrandCloth>
 					<ComponentSpacer>1</ComponentSpacer>
 				</value>
 			</li>
@@ -250,9 +252,10 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AH_f"]/costList/Plasteel</xpath>
 				<value>
+					<Plasteel>90</Plasteel>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
@@ -277,10 +280,11 @@
 				</value>
 			</li>
 			
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="HAR_XO_AH_g"]/costList</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="HAR_XO_AH_g"]/costList/Plasteel</xpath>
 				<value>
-					<DevilstrandCloth>15</DevilstrandCloth>
+					<Plasteel>50</Plasteel>
+					<DevilstrandCloth>10</DevilstrandCloth>
 				</value>
 			</li>
 			


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
